### PR TITLE
require spacy version 2.1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-spacy>=2.1.0
+spacy==2.1.8
 cython>=0.25
 pytest


### PR DESCRIPTION
Resolves an old installation issue: prevent newer versions of spaCy from being installed. Using 2.1.8 instead of 2.1.0 because we'll be installing this from source ([see thread on this issue](https://github.com/huggingface/neuralcoref/issues/209#issuecomment-542692291))